### PR TITLE
Support multiple artists on posts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@oliverbo/gg-common",
-    "version": "5.0.0-rc.1",
+    "version": "5.1.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@oliverbo/gg-common",
-            "version": "5.0.0-rc.1",
+            "version": "5.1.0",
             "license": "ISC",
             "devDependencies": {
                 "@types/jest": "^28.1.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oliverbo/gg-common",
-    "version": "5.0.0",
+    "version": "5.1.0",
     "description": "Common functionality for glamglare site components",
     "main": "dist/index.js",
     "types": "dist/index.d.ts",

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -3,6 +3,7 @@ import {
     Source,
     type Album,
     type ArtistDetails,
+    type Post,
 } from "./index";
 
 describe("public API", () => {
@@ -36,5 +37,19 @@ describe("public API", () => {
         };
 
         expect(artist.albums[0].isComplete).toBe(true);
+    });
+
+    it("supports both multiple and legacy post artist references", () => {
+        const post: Post = {
+            artistRefs: ["artist-one", "artist-two"],
+            title: "A collaborative post",
+        };
+        const legacyPost: Post = {
+            artistRef: "artist-one",
+            title: "A legacy post",
+        };
+
+        expect(post.artistRefs).toEqual(["artist-one", "artist-two"]);
+        expect(legacyPost.artistRef).toBe("artist-one");
     });
 });

--- a/src/model/post.ts
+++ b/src/model/post.ts
@@ -2,6 +2,13 @@ import type { ExternalEntity } from "./external";
 import type { Song } from "./song";
 
 export interface Post extends ExternalEntity {
+    artistRefs?: string[];
+
+    /**
+     * The single artist associated with legacy post records.
+     *
+     * @deprecated Use `artistRefs` for new and updated posts.
+     */
     artistRef?: string;
 }
 


### PR DESCRIPTION
## Summary

- Add optional `artistRefs` support for associating multiple artists with a post.
- Preserve the legacy `artistRef` field with deprecation guidance.
- Bump the package version to 5.1.0.
- Add public API coverage for both artist reference formats.

Closes #48

## Testing

- Added and ran tests covering multiple and legacy post artist references.